### PR TITLE
feat: add lang flag, sync adv config between tabs, bump ecoindex plugins to 7.3.0

### DIFF
--- a/.changeset/feat-lang-flag-sync.md
+++ b/.changeset/feat-lang-flag-sync.md
@@ -3,3 +3,6 @@
 ---
 
 Add lang flag (EN|FR) to AdvConfiguration UI and synchronize all advanced config fields between Simple and JSON tabs
+
+- Bump `lighthouse` from 13.2.0 to 13.3.0
+- Bump `lighthouse-plugin-ecoindex-core` and `lighthouse-plugin-ecoindex-courses` from 7.0.1 to 7.3.0

--- a/.changeset/feat-lang-flag-sync.md
+++ b/.changeset/feat-lang-flag-sync.md
@@ -1,0 +1,5 @@
+---
+"ecoindex-app": minor
+---
+
+Add lang flag (EN|FR) to AdvConfiguration UI and synchronize all advanced config fields between Simple and JSON tabs

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -9,9 +9,9 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "lighthouse": "13.2.0",
-                "lighthouse-plugin-ecoindex-core": "7.0.1",
-                "lighthouse-plugin-ecoindex-courses": "7.0.1"
+                "lighthouse": "13.3.0",
+                "lighthouse-plugin-ecoindex-core": "7.3.0",
+                "lighthouse-plugin-ecoindex-courses": "7.3.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1693,6 +1693,77 @@
             "license": "Apache-2.0"
         },
         "node_modules/lighthouse": {
+            "version": "13.3.0",
+            "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-13.3.0.tgz",
+            "integrity": "sha512-jlsJi7+2i2UQWJY8M+gNDEGoDL1sfZ5J2hArCvmQgMTwKq1KQs5ou2pmasyhrRafdU6jh/Prjuz8rZLbqGuydQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@paulirish/trace_engine": "0.0.64",
+                "@sentry/node": "^9.28.1",
+                "axe-core": "^4.11.4",
+                "chrome-launcher": "^1.2.1",
+                "configstore": "^7.0.0",
+                "csp_evaluator": "1.1.5",
+                "devtools-protocol": "0.0.1625959",
+                "enquirer": "^2.3.6",
+                "http-link-header": "^1.1.1",
+                "intl-messageformat": "^10.5.3",
+                "jpeg-js": "^0.4.4",
+                "js-library-detector": "^6.7.0",
+                "lighthouse-logger": "^2.0.2",
+                "lighthouse-stack-packs": "1.12.3",
+                "lodash-es": "^4.17.21",
+                "lookup-closest-locale": "6.2.0",
+                "open": "^8.4.0",
+                "puppeteer-core": "^24.43.0",
+                "robots-parser": "^3.0.1",
+                "speedline-core": "^1.4.3",
+                "third-party-web": "^0.29.0",
+                "tldts-icann": "^7.0.30",
+                "web-features": "^3.26.0",
+                "ws": "^7.0.0",
+                "yargs": "^17.3.1",
+                "yargs-parser": "^21.0.0"
+            },
+            "bin": {
+                "chrome-debug": "core/scripts/manual-chrome-launcher.js",
+                "lighthouse": "cli/index.js",
+                "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
+            },
+            "engines": {
+                "node": ">=22.19"
+            }
+        },
+        "node_modules/lighthouse-logger": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+            "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+            "dependencies": {
+                "debug": "^4.4.1",
+                "marky": "^1.2.2"
+            }
+        },
+        "node_modules/lighthouse-plugin-ecoindex-core": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/lighthouse-plugin-ecoindex-core/-/lighthouse-plugin-ecoindex-core-7.3.0.tgz",
+            "integrity": "sha512-PvKiJAmEitIhscAGnLNuqjX1ahzKNyyVgat0bx/AMcc7L08tWgwxbrJI8I3SPM4qtddGbkXUjRBwfL+iP3cjOA==",
+            "license": "AGPL-3.0-only",
+            "dependencies": {
+                "ecoindex": "^2.0.1",
+                "lighthouse": "13.2.0",
+                "lighthouse-logger": "^2.0.1",
+                "lodash.round": "^4.0.4",
+                "log-symbols": "4.1.0",
+                "puppeteer-core": "24.42.0"
+            }
+        },
+        "node_modules/lighthouse-plugin-ecoindex-core/node_modules/devtools-protocol": {
+            "version": "0.0.1621552",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1621552.tgz",
+            "integrity": "sha512-uaHF17cjNtGKOVZUoh8W0PGuEwR3pWzY5kz3sj7PK8N/SyBKG3cPnQIehVDDJkSdph6Omv+GlP7GdM/b4DTgJQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/lighthouse-plugin-ecoindex-core/node_modules/lighthouse": {
             "version": "13.2.0",
             "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-13.2.0.tgz",
             "integrity": "sha512-Ra4GsuF+iPRMPUUAARD+zqFMLatr8lI9U3FnFaftsTAcIsi++oAXszlgrcFTpkJk7HYdYQRnhn57EuYUPgQCkQ==",
@@ -1734,33 +1805,10 @@
                 "node": ">=22.19"
             }
         },
-        "node_modules/lighthouse-logger": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
-            "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
-            "dependencies": {
-                "debug": "^4.4.1",
-                "marky": "^1.2.2"
-            }
-        },
-        "node_modules/lighthouse-plugin-ecoindex-core": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/lighthouse-plugin-ecoindex-core/-/lighthouse-plugin-ecoindex-core-7.0.1.tgz",
-            "integrity": "sha512-4jdMNy7zL2qU2oo6MDmWL/AMp7CAx7q4MqKMCRvZ5EN+ukJ4OptS0pNwAYjgD13/fhwKnDaOwlsA/h17nyx/1A==",
-            "license": "AGPL-3.0-only",
-            "dependencies": {
-                "ecoindex": "^2.0.1",
-                "lighthouse": "13.2.0",
-                "lighthouse-logger": "^2.0.1",
-                "lodash.round": "^4.0.4",
-                "log-symbols": "4.1.0",
-                "puppeteer-core": "24.42.0"
-            }
-        },
         "node_modules/lighthouse-plugin-ecoindex-courses": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/lighthouse-plugin-ecoindex-courses/-/lighthouse-plugin-ecoindex-courses-7.0.1.tgz",
-            "integrity": "sha512-MuRsOz2YBkHvJFXa5TNjAavk1CMtIDZA6p8xHMqomtyUTijCQLWdl3i2Y4vzjei9DdQq7Ag8icboSDEvrI26GQ==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/lighthouse-plugin-ecoindex-courses/-/lighthouse-plugin-ecoindex-courses-7.3.0.tgz",
+            "integrity": "sha512-8Fr9t0IARxc08RU1dL6hKONDAQCVzKCM1yIicbGxqp1ImPgERD177uOywjCie49DC0k8Ff9P9NRXHhxId4PxmA==",
             "hasInstallScript": true,
             "license": "AGPL-3.0-only",
             "dependencies": {
@@ -1768,14 +1816,59 @@
                 "ecoindex": "^2.0.1",
                 "handlebars": "^4.7.8",
                 "lighthouse": "13.2.0",
-                "lighthouse-plugin-ecoindex-core": "7.0.1",
+                "lighthouse-plugin-ecoindex-core": "7.3.0",
                 "log-symbols": "4.1.0",
                 "puppeteer": "24.42.0",
                 "puppeteer-core": "24.42.0",
                 "slugify": "^1.6.6"
+            }
+        },
+        "node_modules/lighthouse-plugin-ecoindex-courses/node_modules/devtools-protocol": {
+            "version": "0.0.1621552",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1621552.tgz",
+            "integrity": "sha512-uaHF17cjNtGKOVZUoh8W0PGuEwR3pWzY5kz3sj7PK8N/SyBKG3cPnQIehVDDJkSdph6Omv+GlP7GdM/b4DTgJQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/lighthouse-plugin-ecoindex-courses/node_modules/lighthouse": {
+            "version": "13.2.0",
+            "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-13.2.0.tgz",
+            "integrity": "sha512-Ra4GsuF+iPRMPUUAARD+zqFMLatr8lI9U3FnFaftsTAcIsi++oAXszlgrcFTpkJk7HYdYQRnhn57EuYUPgQCkQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@paulirish/trace_engine": "0.0.64",
+                "@sentry/node": "^9.28.1",
+                "axe-core": "^4.11.4",
+                "chrome-launcher": "^1.2.1",
+                "configstore": "^7.0.0",
+                "csp_evaluator": "1.1.5",
+                "devtools-protocol": "0.0.1621552",
+                "enquirer": "^2.3.6",
+                "http-link-header": "^1.1.1",
+                "intl-messageformat": "^10.5.3",
+                "jpeg-js": "^0.4.4",
+                "js-library-detector": "^6.7.0",
+                "lighthouse-logger": "^2.0.2",
+                "lighthouse-stack-packs": "1.12.3",
+                "lodash-es": "^4.17.21",
+                "lookup-closest-locale": "6.2.0",
+                "open": "^8.4.0",
+                "puppeteer-core": "^24.42.0",
+                "robots-parser": "^3.0.1",
+                "speedline-core": "^1.4.3",
+                "third-party-web": "^0.29.0",
+                "tldts-icann": "^7.0.29",
+                "web-features": "^3.25.0",
+                "ws": "^7.0.0",
+                "yargs": "^17.3.1",
+                "yargs-parser": "^21.0.0"
             },
-            "peerDependencies": {
-                "lighthouse-plugin-ecoindex-core": "7.0.1"
+            "bin": {
+                "chrome-debug": "core/scripts/manual-chrome-launcher.js",
+                "lighthouse": "cli/index.js",
+                "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
+            },
+            "engines": {
+                "node": ">=22.19"
             }
         },
         "node_modules/lighthouse-stack-packs": {
@@ -1783,11 +1876,77 @@
             "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.12.3.tgz",
             "integrity": "sha512-d8IsOpE83kbANgnM+Tp8+x6HcMpX9o2ITBiUERssgzAIFdZCQzs/f4k6D0DLQTE59enml9mbAOU52Wu35exWtg=="
         },
+        "node_modules/lighthouse/node_modules/@puppeteer/browsers": {
+            "version": "2.13.2",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+            "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "debug": "^4.4.3",
+                "extract-zip": "^2.0.1",
+                "progress": "^2.0.3",
+                "proxy-agent": "^6.5.0",
+                "semver": "^7.7.4",
+                "tar-fs": "^3.1.1",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "browsers": "lib/cjs/main-cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/lighthouse/node_modules/devtools-protocol": {
-            "version": "0.0.1621552",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1621552.tgz",
-            "integrity": "sha512-uaHF17cjNtGKOVZUoh8W0PGuEwR3pWzY5kz3sj7PK8N/SyBKG3cPnQIehVDDJkSdph6Omv+GlP7GdM/b4DTgJQ==",
+            "version": "0.0.1625959",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1625959.tgz",
+            "integrity": "sha512-wRBSU330hwOLLcb3N4NIe3eFs6MgT6ku3AiZONjnTSJ7f3dVchJfn6nE0Lfos9jK1na15bgp7xLhaCx40Y47NQ==",
             "license": "BSD-3-Clause"
+        },
+        "node_modules/lighthouse/node_modules/puppeteer-core": {
+            "version": "24.43.1",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+            "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@puppeteer/browsers": "2.13.2",
+                "chromium-bidi": "14.0.0",
+                "debug": "^4.4.3",
+                "devtools-protocol": "0.0.1608973",
+                "typed-query-selector": "^2.12.2",
+                "webdriver-bidi-protocol": "0.4.1",
+                "ws": "^8.20.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
+            "version": "0.0.1608973",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+            "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
+            "version": "8.20.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",

--- a/lib/package.json
+++ b/lib/package.json
@@ -10,8 +10,8 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "lighthouse": "13.2.0",
-        "lighthouse-plugin-ecoindex-core": "7.0.1",
-        "lighthouse-plugin-ecoindex-courses": "7.0.1"
+        "lighthouse": "13.3.0",
+        "lighthouse-plugin-ecoindex-core": "7.3.0",
+        "lighthouse-plugin-ecoindex-courses": "7.3.0"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "i18next": "^25.7.1",
                 "i18next-fs-backend": "^2.6.1",
                 "i18next-resources-to-backend": "^1.2.1",
-                "lighthouse-plugin-ecoindex-courses": "^7.0.1",
+                "lighthouse-plugin-ecoindex-courses": "^7.3.0",
                 "lucide-react": "^0.555.0",
                 "react": "^19.2.1",
                 "react-dom": "^19.2.1",
@@ -5972,9 +5972,9 @@
             }
         },
         "node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-            "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+            "version": "1.41.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+            "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
@@ -15309,9 +15309,9 @@
             }
         },
         "node_modules/lighthouse-plugin-ecoindex-core": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/lighthouse-plugin-ecoindex-core/-/lighthouse-plugin-ecoindex-core-7.0.1.tgz",
-            "integrity": "sha512-4jdMNy7zL2qU2oo6MDmWL/AMp7CAx7q4MqKMCRvZ5EN+ukJ4OptS0pNwAYjgD13/fhwKnDaOwlsA/h17nyx/1A==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/lighthouse-plugin-ecoindex-core/-/lighthouse-plugin-ecoindex-core-7.3.0.tgz",
+            "integrity": "sha512-PvKiJAmEitIhscAGnLNuqjX1ahzKNyyVgat0bx/AMcc7L08tWgwxbrJI8I3SPM4qtddGbkXUjRBwfL+iP3cjOA==",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "ecoindex": "^2.0.1",
@@ -15323,9 +15323,9 @@
             }
         },
         "node_modules/lighthouse-plugin-ecoindex-courses": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/lighthouse-plugin-ecoindex-courses/-/lighthouse-plugin-ecoindex-courses-7.0.1.tgz",
-            "integrity": "sha512-MuRsOz2YBkHvJFXa5TNjAavk1CMtIDZA6p8xHMqomtyUTijCQLWdl3i2Y4vzjei9DdQq7Ag8icboSDEvrI26GQ==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/lighthouse-plugin-ecoindex-courses/-/lighthouse-plugin-ecoindex-courses-7.3.0.tgz",
+            "integrity": "sha512-8Fr9t0IARxc08RU1dL6hKONDAQCVzKCM1yIicbGxqp1ImPgERD177uOywjCie49DC0k8Ff9P9NRXHhxId4PxmA==",
             "hasInstallScript": true,
             "license": "AGPL-3.0-only",
             "dependencies": {
@@ -15333,14 +15333,11 @@
                 "ecoindex": "^2.0.1",
                 "handlebars": "^4.7.8",
                 "lighthouse": "13.2.0",
-                "lighthouse-plugin-ecoindex-core": "7.0.1",
+                "lighthouse-plugin-ecoindex-core": "7.3.0",
                 "log-symbols": "4.1.0",
                 "puppeteer": "24.42.0",
                 "puppeteer-core": "24.42.0",
                 "slugify": "^1.6.6"
-            },
-            "peerDependencies": {
-                "lighthouse-plugin-ecoindex-core": "7.0.1"
             }
         },
         "node_modules/lighthouse-stack-packs": {
@@ -21179,9 +21176,9 @@
             }
         },
         "node_modules/third-party-web": {
-            "version": "0.29.0",
-            "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.29.0.tgz",
-            "integrity": "sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==",
+            "version": "0.29.2",
+            "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.29.2.tgz",
+            "integrity": "sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==",
             "license": "MIT"
         },
         "node_modules/through": {
@@ -22067,9 +22064,9 @@
             }
         },
         "node_modules/web-features": {
-            "version": "3.26.0",
-            "resolved": "https://registry.npmjs.org/web-features/-/web-features-3.26.0.tgz",
-            "integrity": "sha512-1qXkBvgi2H1uZ3AmP9GOOF5+LrlO94bJxgh6Kh12yW6wYQQtjXv7ou3ADo3dIuHB98WlHtGp8bjd/w8UQI6tHw==",
+            "version": "3.27.0",
+            "resolved": "https://registry.npmjs.org/web-features/-/web-features-3.27.0.tgz",
+            "integrity": "sha512-Usye0RO960BDWH+cnE2TBnzKkoYhLAETSpuO5A8yFnbg67gjr0EquN1f0/suO8iruDFHP9W9oAU2hGsoyoxotA==",
             "license": "Apache-2.0"
         },
         "node_modules/webdriver-bidi-protocol": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ecoindex-app",
-    "version": "0.8.0",
+    "version": "0.11.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ecoindex-app",
-            "version": "0.8.0",
+            "version": "0.11.1",
             "hasInstallScript": true,
             "license": "AGPL-3.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
         "release": "npm run build && changeset publish",
         "localize:generate": "babel -f .babelrc 'src/**/*.{js,jsx,ts,tsx}' --out-dir .babel-temp --copy-files --quiet && rm -rf .babel-temp",
         "postinstall": "cd lib && npm ci",
-        "update-packages": "cd lib && rm -rf node_modules && npm i lighthouse@latest lighthouse-plugin-ecoindex-core@latest lighthouse-plugin-ecoindex-courses@latest --save --save-exact",
+        "update-packages": "sh update-packages.sh",
+        "update-packages-old": "npm i lighthouse-plugin-ecoindex-courses@latest && cd lib && rm -rf node_modules && npm i lighthouse@latest lighthouse-plugin-ecoindex-core@latest lighthouse-plugin-ecoindex-courses@latest --save --save-exact",
         "prepare": "husky",
         "clean": "rm -rf node_modules && rm -rf lib/node_modules && rm -rf .webpack && rm -rf .vite && rm -rf out"
     },
@@ -131,7 +132,7 @@
         "i18next": "^25.7.1",
         "i18next-fs-backend": "^2.6.1",
         "i18next-resources-to-backend": "^1.2.1",
-        "lighthouse-plugin-ecoindex-courses": "^7.0.1",
+        "lighthouse-plugin-ecoindex-courses": "^7.3.0",
         "lucide-react": "^0.555.0",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -19,6 +19,7 @@ export interface IAdvancedMesureData {
     'output-path'?: string
     'user-agent'?: string
     'output-name'?: string
+    lang?: 'en' | 'fr'
 }
 
 export interface ICourse {
@@ -131,6 +132,7 @@ declare global {
         'output-path'?: string
         'user-agent'?: string
         'output-name'?: string
+        lang?: 'en' | 'fr'
     }
     interface IJsonMesureData extends IAdvancedMesureData {
         courses: ICourse[]

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -222,7 +222,12 @@
     "switchToTextMode": "Switch to text mode",
     "switchToFormMode": "Switch to form mode",
     "textModeFormat": "Format: one key=value pair per line. Example: Authorization=Bearer token",
-    "textModeFormatEnvVars": "Format: one KEY=value pair per line. Keys will be converted to uppercase. Example: API_KEY=your-key"
+    "textModeFormatEnvVars": "Format: one KEY=value pair per line. Keys will be converted to uppercase. Example: API_KEY=your-key",
+    "lang": {
+      "title": "Report language",
+      "description": "Language used for Lighthouse report labels.",
+      "default": "Default (EN)"
+    }
   },
   "simpleUrlsList": {
     "textModeFormat": "Format: one URL per line. Example: https://www.example.com/"

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -222,7 +222,12 @@
     "switchToTextMode": "Basculer en mode texte",
     "switchToFormMode": "Basculer en mode formulaire",
     "textModeFormat": "Format: une paire clé=valeur par ligne. Exemple: Authorization=Bearer token",
-    "textModeFormatEnvVars": "Format: une paire CLÉ=valeur par ligne. Les clés seront converties en majuscules. Exemple: API_KEY=votre-clé"
+    "textModeFormatEnvVars": "Format: une paire CLÉ=valeur par ligne. Les clés seront converties en majuscules. Exemple: API_KEY=votre-clé",
+    "lang": {
+      "title": "Langue des rapports",
+      "description": "Langue utilisée pour les libellés des rapports Lighthouse.",
+      "default": "Par défaut (EN)"
+    }
   },
   "simpleUrlsList": {
     "textModeFormat": "Format: une URL par ligne. Exemple: https://www.example.com/"

--- a/src/main/Updater.ts
+++ b/src/main/Updater.ts
@@ -246,28 +246,32 @@ class Updater {
         try {
             // Utiliser la Promise au lieu du callback (API moderne d'Electron)
             const result = await dialog.showMessageBox(options)
-            
+
             if (result.response === 0) {
                 // L'utilisateur a choisi "Redémarrer"
-                updaterLog.log('User chose to restart, calling quitAndInstall()')
-                
+                updaterLog.log(
+                    'User chose to restart, calling quitAndInstall()'
+                )
+
                 // Fermer toutes les fenêtres avant quitAndInstall pour s'assurer que l'application est dans un état propre
                 // Cela est particulièrement important sur macOS mais peut aider sur toutes les plateformes
                 const allWindows = BrowserWindow.getAllWindows()
-                updaterLog.log(`Closing ${allWindows.length} window(s) before restart`)
+                updaterLog.log(
+                    `Closing ${allWindows.length} window(s) before restart`
+                )
                 allWindows.forEach((window) => {
                     window.close()
                 })
-                
+
                 // Attendre un court délai pour que les fenêtres se ferment proprement
                 // avant d'appeler quitAndInstall
                 await new Promise((resolve) => setTimeout(resolve, 100))
-                
+
                 // Appeler quitAndInstall avec restart=true pour redémarrer automatiquement
                 // Le premier paramètre (restart) indique de redémarrer après l'installation
                 // Le second paramètre (isSilent) indique si l'installation doit être silencieuse
-                updaterLog.log('Calling autoUpdater.quitAndInstall(true, false)')
-                autoUpdater.quitAndInstall(true, false)
+                updaterLog.log('Calling autoUpdater.quitAndInstall()')
+                autoUpdater.quitAndInstall()
             } else {
                 updaterLog.log('User chose to restart later')
             }
@@ -290,13 +294,15 @@ class Updater {
         }
 
         updaterLog.log('testUpdateDialog: Simulating update-downloaded event')
-        
+
         // Simuler l'événement update-downloaded avec des données de test
         const mockEvent = {} as Event
-        const mockReleaseNotes = 'Version de test - Correction du redémarrage après mise à jour'
+        const mockReleaseNotes =
+            'Version de test - Correction du redémarrage après mise à jour'
         const mockReleaseName = 'v0.7.1-test'
         const mockReleaseDate = new Date()
-        const mockUpdateURL = 'https://github.com/cnumr/EcoindexApp/releases/tag/v0.7.1-test'
+        const mockUpdateURL =
+            'https://github.com/cnumr/EcoindexApp/releases/tag/v0.7.1-test'
 
         await this.onUpdateDownloaded(
             mockEvent,

--- a/src/main/handlers/HandleCollectAll.ts
+++ b/src/main/handlers/HandleCollectAll.ts
@@ -530,6 +530,9 @@ export const handleSimpleCollect = async (
             [key: string]: string
         }
         collectDatas.command['user-agent'] = localAdvConfig['user-agent']
+        if (localAdvConfig['lang']) {
+            collectDatas.command['lang'] = localAdvConfig['lang']
+        }
         // Le script Puppeteer est optionnel, utilisé pour des interactions complexes
         if (localAdvConfig['puppeteer-script']) {
             collectDatas.command['puppeteer-script'] =
@@ -693,6 +696,9 @@ export const handleJsonSaveAndCollect = async (
                 jsonDatas.output as ('statement' | 'json' | 'html')[],
                 jsonFilePath
             )
+            if (jsonDatas['lang']) {
+                collectDatas.command['lang'] = jsonDatas['lang']
+            }
             _debugLogs('Json measure start...')
             _debugLogs(`JSON datas ${JSON.stringify(jsonDatas, null, 2)}`)
             try {

--- a/src/renderer/components/AdvConfiguration.tsx
+++ b/src/renderer/components/AdvConfiguration.tsx
@@ -458,6 +458,29 @@ export const AdvConfiguration: FC<ILayout> = ({
                     }}
                 />
             </fieldset>
+            <fieldset>
+                <legend>{t('advConfiguration.lang.title')}</legend>
+                <p>{t('advConfiguration.lang.description')}</p>
+                <select
+                    id="lang"
+                    value={configurationDatas?.lang ?? ''}
+                    className="flex h-10 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    onChange={(e) => {
+                        const value = e.target.value as 'en' | 'fr' | ''
+                        setConfigurationDatas?.({
+                            ...configurationDatas,
+                            lang: value === '' ? undefined : value,
+                        })
+                        setUpdated?.(true)
+                    }}
+                >
+                    <option value="">
+                        {t('advConfiguration.lang.default')}
+                    </option>
+                    <option value="en">EN</option>
+                    <option value="fr">FR</option>
+                </select>
+            </fieldset>
         </details>
     )
 }

--- a/src/renderer/components/JsonPanMesure.tsx
+++ b/src/renderer/components/JsonPanMesure.tsx
@@ -387,6 +387,7 @@ export const JsonPanMesure: FC<ILayout> = ({
                                 'extra-header': config['extra-header'],
                                 output: config['output'],
                                 'audit-category': config['audit-category'],
+                                lang: config['lang'],
                             }
                             if (config['audit-category']) {
                                 _jsonDatas['puppeteer-script'] =
@@ -518,7 +519,9 @@ export const JsonPanMesure: FC<ILayout> = ({
                                                 isFullWidth
                                                 enableTextMode={true}
                                                 placeholder="https://www.example.com/&#10;https://www.example2.com/"
-                                                textModeFormat={t('simpleUrlsList.textModeFormat')}
+                                                textModeFormat={t(
+                                                    'simpleUrlsList.textModeFormat'
+                                                )}
                                             />
                                         )}
                                     </div>

--- a/src/renderer/components/SimplePanMesure.tsx
+++ b/src/renderer/components/SimplePanMesure.tsx
@@ -77,6 +77,7 @@ export const SimplePanMesure: FC<ISimpleMesureLayout> = ({
                                 'extra-header': config['extra-header'],
                                 output: config['output'],
                                 'audit-category': config['audit-category'],
+                                lang: config['lang'],
                             }
                             if (config['audit-category']) {
                                 _jsonDatas['puppeteer-script'] =

--- a/src/renderer/main_window/App.tsx
+++ b/src/renderer/main_window/App.tsx
@@ -280,9 +280,30 @@ function TheApp() {
                                             envVars={envVars}
                                             setEnvVars={setEnvVars}
                                             localAdvConfig={localAdvConfig}
-                                            setLocalAdvConfig={
-                                                setLocalAdvConfig
-                                            }
+                                            setLocalAdvConfig={(config) => {
+                                                setLocalAdvConfig(config)
+                                                setJsonDatas((prev) => ({
+                                                    ...prev,
+                                                    'extra-header':
+                                                        config['extra-header'],
+                                                    output: config['output'],
+                                                    'audit-category':
+                                                        config[
+                                                            'audit-category'
+                                                        ],
+                                                    'puppeteer-script':
+                                                        config[
+                                                            'puppeteer-script'
+                                                        ],
+                                                    'user-agent':
+                                                        config['user-agent'],
+                                                    'output-path':
+                                                        config['output-path'],
+                                                    'output-name':
+                                                        config['output-name'],
+                                                    lang: config.lang,
+                                                }))
+                                            }}
                                         />
                                     </TabsContent>
                                     <TabsContent value="json-mesure">
@@ -293,7 +314,28 @@ function TheApp() {
                                             }
                                             language={i18nResources.language}
                                             jsonDatas={jsonDatas}
-                                            setJsonDatas={setJsonDatas}
+                                            setJsonDatas={(data) => {
+                                                setJsonDatas(data)
+                                                setLocalAdvConfig((prev) => ({
+                                                    ...prev,
+                                                    'extra-header':
+                                                        data['extra-header'],
+                                                    output: data['output'],
+                                                    'audit-category':
+                                                        data['audit-category'],
+                                                    'puppeteer-script':
+                                                        data[
+                                                            'puppeteer-script'
+                                                        ],
+                                                    'user-agent':
+                                                        data['user-agent'],
+                                                    'output-path':
+                                                        data['output-path'],
+                                                    'output-name':
+                                                        data['output-name'],
+                                                    lang: data.lang,
+                                                }))
+                                            }}
                                             mesure={(envVars) =>
                                                 runJsonSaveAndCollect(
                                                     true,


### PR DESCRIPTION
## Summary

- Add a lang selector (EN/FR/default) in `AdvConfiguration` to control Lighthouse report language, written to `command-data.json` for both simple and JSON collect workflows
- Synchronize all `IAdvancedMesureData` fields (`output`, `audit-category`, `extra-header`, `puppeteer-script`, `user-agent`, `output-path`, `output-name`, `lang`) bidirectionally between the Simple and JSON tabs
- Bump `lighthouse` 13.2.0 → 13.3.0, `lighthouse-plugin-ecoindex-core` and `lighthouse-plugin-ecoindex-courses` 7.0.1 → 7.3.0
- Fix `Updater.ts`: `autoUpdater.quitAndInstall()` was called with arguments that Electron's native API does not accept